### PR TITLE
Add syntax highlighting support for YAML files

### DIFF
--- a/src/data/def/yaml.lang
+++ b/src/data/def/yaml.lang
@@ -1,0 +1,42 @@
+format = 3
+
+%include = "def/generic.lang"
+
+%define {
+  style-scope = "yaml"
+
+  yaml {
+    # Commenti con il cancelletto #
+    %highlight { use = "hash-comment" }
+
+    # I tre trattini di inizio documento ---
+    %highlight {
+        regex = "^---"
+        style = "whitespace"
+    }
+
+    # Chiavi YAML (parola seguita obbligatoriamente da : )
+    %highlight {
+        regex = "([\w-]+)(:)(?=\s|$)"
+        style = "keyword"
+    }
+
+    # Valori Booleani e Null
+    %highlight {
+        regex = "(?<![\w-])(?:true|false|null|TRUE|FALSE|NULL)(?![\w-])"
+        style = "keyword"
+    }
+
+    # Numeri interi e decimali
+    %highlight {
+        regex = "\b[0-9]+(?:\.[0-9]+)?\b"
+        style = "number"
+    }
+
+    # Stringhe con doppi o singoli apici (riutilizza le definizioni standard)
+    %highlight { use = "dqs-wce" }
+    %highlight { use = "sqs-wce" }
+  }
+}
+
+%highlight { use = "yaml" }

--- a/src/data/lang.map
+++ b/src/data/lang.map
@@ -146,6 +146,19 @@ format = 1
   file-regex = "\.md$"
   lang-file = "markdown.lang"
 }
+%lang {
+        name = "YAML"
+        name-regex = "^(?i)yaml$"
+        file-regex = "(?i)\.yaml$"
+        lang-file = "yaml.lang"
+}
+%lang {
+        name = "YML"
+        name-regex = "^(?i)yml$"
+        file-regex = "(?i)\.yml$"
+        lang-file = "yaml.lang"
+}
+
 # This definition should be last, because it matches for any file in /etc
 %lang {
 	name = "Configuration file"

--- a/src/data/yaml.lang
+++ b/src/data/yaml.lang
@@ -1,0 +1,5 @@
+format = 3
+
+%include = "def/yaml.lang"
+
+%highlight { use = "yaml" }


### PR DESCRIPTION
This Pull Request adds native syntax highlighting support for YAML (`.yaml` and `.yml`) files to `libt3highlight`.

The implementation includes:
1. A base syntax definition template (`src/data/def/yaml.lang`) supporting comments, document markers (`---`), keys, booleans, numbers, and strings.
2. An activator language wrapper (`src/data/yaml.lang`).
3. Appropriate file mapping configurations added to `src/data/lang.map` right before the catch-all configuration file block.

Tested locally on Tilde editor and everything highlights as expected.
